### PR TITLE
Improve error boundary with server logging

### DIFF
--- a/app/api/log-error/route.ts
+++ b/app/api/log-error/route.ts
@@ -1,0 +1,17 @@
+export const dynamic = "force-dynamic";
+
+import { NextResponse } from "next/server";
+
+export async function POST(req: Request) {
+  try {
+    const data = await req.json();
+    console.error("🔴 Log d'erreur reçu:", data);
+    return NextResponse.json({ message: "Erreur enregistrée" });
+  } catch (error) {
+    console.error("❌ Erreur dans /api/log-error :", error);
+    return NextResponse.json(
+      { message: "Erreur serveur" },
+      { status: 500 }
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- enhance ErrorBoundary with logging to `/api/log-error`
- add `/api/log-error` endpoint to collect error reports

## Testing
- `npm run build` *(fails: `@prisma/client did not initialize yet`)*

------
https://chatgpt.com/codex/tasks/task_e_6840b286565c8323a323f438505f9f8d