### PR TITLE
Improve GenerateButton component

### DIFF
--- a/components/GenerateButton.tsx
+++ b/components/GenerateButton.tsx
@@ -1,26 +1,50 @@
 "use client";
 
-import React from "react";
+import React, { ComponentPropsWithoutRef } from "react";
 import { motion } from "framer-motion";
-import { Sparkles } from "lucide-react";
+import { Sparkles, Loader2 } from "lucide-react";
+import clsx from "clsx";
 
-export default function GenerateButton() {
-  const handleClick = () => {
-    alert("Fonctionnalité de génération en cours d'intégration !");
-  };
+interface GenerateButtonProps
+  extends ComponentPropsWithoutRef<typeof motion.button> {
+  /**
+   * Affiche un indicateur de chargement dans le bouton.
+   */
+  loading?: boolean;
+  /**
+   * Libellé affiché à côté de l'icône.
+   */
+  label?: string;
+}
 
+export default function GenerateButton({
+  loading = false,
+  label = "Générer un avis IA",
+  className,
+  disabled,
+  ...props
+}: GenerateButtonProps) {
   return (
     <motion.button
       whileHover={{ scale: 1.05 }}
-      whileTap={{ scale: 0.97 }}
+      whileTap={{ scale: 0.95 }}
       initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.5 }}
-      onClick={handleClick}
-      className="flex items-center gap-2 px-6 py-3 bg-gradient-to-r from-pink-500 to-red-500 text-white font-semibold rounded-full shadow-lg hover:shadow-xl transition-all duration-300"
+      disabled={disabled || loading}
+      className={clsx(
+        "relative flex items-center gap-2 px-6 py-3 rounded-full font-semibold text-white shadow-lg transition-colors duration-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-pink-500",
+        "bg-gradient-to-r from-pink-500 to-red-500 hover:from-pink-600 hover:to-red-600 disabled:opacity-60",
+        className
+      )}
+      {...props}
     >
-      <Sparkles className="w-5 h-5 animate-pulse" />
-      Générer un avis IA
+      {loading ? (
+        <Loader2 className="w-5 h-5 animate-spin" aria-hidden="true" />
+      ) : (
+        <Sparkles className="w-5 h-5" aria-hidden="true" />
+      )}
+      <span>{label}</span>
     </motion.button>
   );
 }


### PR DESCRIPTION
## Summary
- refactor GenerateButton with props and loading state for professional use

## Testing
- `node -v`
- `npm -v`

------
https://chatgpt.com/codex/tasks/task_e_6840b30ee8e8832389d2a877ee32ccec