### PR TITLE
Improve PageWrapper component

### DIFF
--- a/components/PageWrapper.tsx
+++ b/components/PageWrapper.tsx
@@ -1,28 +1,47 @@
 "use client";
 
-import { motion, AnimatePresence } from "framer-motion";
+import React, { useEffect, type ComponentPropsWithoutRef } from "react";
+import { motion, AnimatePresence, type Variants } from "framer-motion";
 import { usePathname } from "next/navigation";
-import React from "react";
+import clsx from "clsx";
 
-interface PageWrapperProps {
+interface PageWrapperProps extends ComponentPropsWithoutRef<typeof motion.div> {
   children: React.ReactNode;
 }
 
-export default function PageWrapper({ children }: PageWrapperProps) {
+const variants: Variants = {
+  initial: { opacity: 0, y: 20 },
+  animate: { opacity: 1, y: 0 },
+  exit: { opacity: 0, y: -20 },
+};
+
+export default function PageWrapper({
+  children,
+  className,
+  ...props
+}: PageWrapperProps) {
   const pathname = usePathname();
+
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      window.scrollTo({ top: 0, behavior: "smooth" });
+    }
+  }, [pathname]);
 
   return (
     <AnimatePresence mode="wait">
       <motion.div
         key={pathname}
-        initial={{ opacity: 0, y: 10 }}
-        animate={{ opacity: 1, y: 0 }}
-        exit={{ opacity: 0, y: -10 }}
-        transition={{
-          duration: 0.4,
-          ease: "easeInOut"
-        }}
-        className="min-h-screen bg-white dark:bg-black text-black dark:text-white"
+        variants={variants}
+        initial="initial"
+        animate="animate"
+        exit="exit"
+        transition={{ duration: 0.4, ease: "easeInOut" }}
+        className={clsx(
+          "min-h-screen bg-white dark:bg-black text-black dark:text-white",
+          className
+        )}
+        {...props}
       >
         {children}
       </motion.div>


### PR DESCRIPTION
## Summary
- refactor `PageWrapper` to support extra props and custom classNames
- add page transition variants, smooth scroll to top and clsx

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840b3708e508323ba908883124d336f