### PR TITLE
Improve SplashScreen component

### DIFF
--- a/components/SplashScreen.tsx
+++ b/components/SplashScreen.tsx
@@ -2,39 +2,47 @@
 
 import React from "react";
 import { motion } from "framer-motion";
-import Lottie from "lottie-react";
-import loadingAnim from "@/animations/loading.json";
+import dynamic from "next/dynamic";
+import loadingAnimation from "@/animations/loading.json";
 
-export default function SplashScreen() {
+const Lottie = dynamic(() => import("lottie-react"), { ssr: false });
+
+interface SplashScreenProps {
+  message?: string;
+}
+export default function SplashScreen({
+  message = "Chargement en cours...",
+}: SplashScreenProps) {
   return (
     <motion.div
       className="fixed inset-0 z-[9999] flex flex-col items-center justify-center bg-gradient-to-br from-black via-zinc-900 to-zinc-950 text-white"
       initial={{ opacity: 1 }}
       animate={{ opacity: 1 }}
       exit={{ opacity: 0 }}
-      transition={{ duration: 1 }}
+      transition={{ duration: 0.5 }}
     >
       <motion.div
+        className="w-32 h-32 md:w-40 md:h-40"
         initial={{ scale: 0.8, opacity: 0 }}
         animate={{ scale: 1, opacity: 1 }}
-        transition={{ delay: 0.3, duration: 0.6, ease: "easeOut" }}
-        className="w-40 h-40"
+        transition={{ delay: 0.2, duration: 0.6, ease: "easeOut" }}
       >
         <Lottie
-          animationData={loadingAnim}
+          animationData={loadingAnimation}
           loop
+          aria-label="Animation de chargement"
           className="w-full h-full drop-shadow-lg"
         />
       </motion.div>
 
-      <motion.h1
-        className="mt-6 text-xl font-semibold tracking-wide"
-        initial={{ opacity: 0, y: 20 }}
+      <motion.p
+        className="mt-6 text-base font-medium tracking-wide text-center"
+        initial={{ opacity: 0, y: 10 }}
         animate={{ opacity: 1, y: 0 }}
-        transition={{ delay: 0.8 }}
+        transition={{ delay: 0.5 }}
       >
-        Chargement de votre expérience IA...
-      </motion.h1>
+        {message}
+      </motion.p>
     </motion.div>
   );
 }


### PR DESCRIPTION
## Summary
- modernize `SplashScreen` component with TypeScript props
- load Lottie dynamically and fine tune animations

## Testing
- `npm run build` *(fails: @prisma/client did not initialize yet)*

------
https://chatgpt.com/codex/tasks/task_e_6840b3be9d0483238684d1c93776c468