### PR TITLE
Improve StatsSummary component

### DIFF
--- a/components/StatsSummary.tsx
+++ b/components/StatsSummary.tsx
@@ -1,21 +1,40 @@
 "use client";
 
 import React from "react";
+import { motion } from "framer-motion";
+import CountUp from "react-countup";
+import { MessageSquareText, TrendingUp, Users } from "lucide-react";
 
-const stats = [
-  { label: "Avis générés", value: 124 },
-  { label: "Taux de conversion", value: "12.5%" },
-  { label: "Utilisateurs actifs", value: 842 },
+type Stat = {
+  label: string;
+  value: number;
+  suffix?: string;
+  Icon: React.ComponentType<React.SVGProps<SVGSVGElement>>;
+};
+
+const stats: Stat[] = [
+  { label: "Avis générés", value: 124, Icon: MessageSquareText },
+  { label: "Taux de conversion", value: 12.5, suffix: "%", Icon: TrendingUp },
+  { label: "Utilisateurs actifs", value: 842, Icon: Users },
 ];
 
 export default function StatsSummary() {
   return (
-    <div className="grid grid-cols-1 md:grid-cols-3 gap-6 my-10">
-      {stats.map((stat, i) => (
-        <div key={i} className="bg-white dark:bg-zinc-900 p-6 rounded-xl shadow-xl text-center border border-zinc-200 dark:border-zinc-700 transition-all duration-300 hover:scale-105">
-          <p className="text-sm text-gray-500 dark:text-gray-400">{stat.label}</p>
-          <p className="text-4xl font-extrabold text-marque mt-1 tracking-tight">{stat.value}</p>
-        </div>
+    <div className="grid grid-cols-1 gap-6 my-10 md:grid-cols-3">
+      {stats.map(({ label, value, suffix, Icon }, index) => (
+        <motion.div
+          key={label}
+          className="rounded-xl border border-zinc-200 bg-white p-6 text-center shadow-xl transition-colors dark:border-zinc-700 dark:bg-zinc-900"
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          transition={{ delay: index * 0.2 }}
+        >
+          <Icon className="mx-auto mb-2 h-8 w-8 text-marque" />
+          <p className="text-sm text-gray-500 dark:text-gray-400">{label}</p>
+          <p className="mt-1 text-4xl font-extrabold tracking-tight text-marque">
+            <CountUp end={value} duration={1.5} suffix={suffix ?? ""} />
+          </p>
+        </motion.div>
       ))}
     </div>
   );


### PR DESCRIPTION
## Summary
- enhance `StatsSummary` with CountUp animations, icons and framer-motion

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840b3e2379483239c97ac6b52654283