### PR TITLE
Fix README code block and add usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,19 @@ Bienvenue sur **AvisAI**, une solution SaaS alimentée par l'IA pour générer, 
 git clone https://github.com/tonuser/avisai.git
 cd avisai
 npm install
+```
+
+### Utilisation
+
+Pour démarrer le serveur de développement :
+
+```bash
+npm run dev
+```
+
+Pour construire et lancer l'application en production :
+
+```bash
+npm run build
+npm start
+```


### PR DESCRIPTION
## Summary
- fix an unclosed bash code block in README
- add directions for starting the dev server and building for production

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840c8979ad483239b3ea7691fe9f8ab