### PR TITLE
Fix default site colors

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -11,8 +11,8 @@ body {
   font-family: 'Inter', sans-serif;
   scroll-behavior: smooth;
   overflow-x: hidden;
-  background-color: #000;
-  color: #fff;
+  background-color: #ffffff;
+  color: #000000;
 }
 
 /* === Typography === */


### PR DESCRIPTION
## Summary
- adjust body background and text defaults to light theme

## Testing
- `npm run build` *(fails: Failed to fetch font `Inter`)*

------
https://chatgpt.com/codex/tasks/task_e_68414b406f188323badc571484a57993