### PR TITLE
Implement newsletter signup with Sendinblue

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,16 @@ Pour construire et lancer l'application en production :
 npm run build
 npm start
 ```
+
+### Configuration newsletter
+
+AvisAI s'appuie sur Sendinblue pour stocker les abonnés. Créez un fichier
+`.env.local` à la racine et renseignez :
+
+```bash
+SENDINBLUE_API_KEY=VotreCléAPI
+SENDINBLUE_LIST_ID=123
+```
+
+L'API `/api/newsletter` utilisera ces informations pour ajouter chaque email
+inscrit dans la liste spécifiée.

--- a/app/api/newsletter/route.ts
+++ b/app/api/newsletter/route.ts
@@ -21,9 +21,43 @@ export async function POST(req: Request) {
       );
     }
 
-    // 👉 Ici, connectez-vous à votre fournisseur d'emailing ou base de données
-    // Exemple : await fetch(process.env.NEWSLETTER_ENDPOINT!, { ... })
-    console.log(`✅ Nouvelle inscription newsletter : ${email}`);
+    // 👉 Inscription via Sendinblue
+    const apiKey = process.env.SENDINBLUE_API_KEY;
+    const listId = process.env.SENDINBLUE_LIST_ID;
+
+    if (!apiKey || !listId) {
+      console.error(
+        "❌ Configuration Sendinblue manquante: ajoutez SENDINBLUE_API_KEY et SENDINBLUE_LIST_ID"
+      );
+    } else {
+      const res = await fetch("https://api.sendinblue.com/v3/contacts", {
+        method: "POST",
+        headers: {
+          "api-key": apiKey,
+          "Content-Type": "application/json",
+          Accept: "application/json",
+        },
+        body: JSON.stringify({
+          email,
+          listIds: [Number(listId)],
+          updateEnabled: true,
+        }),
+      });
+
+      if (!res.ok) {
+        console.error(
+          "❌ Erreur Sendinblue:",
+          res.status,
+          await res.text()
+        );
+        return NextResponse.json(
+          { message: "Erreur lors de l'inscription" },
+          { status: 500 }
+        );
+      }
+
+      console.log(`✅ Nouvelle inscription newsletter : ${email}`);
+    }
 
     return NextResponse.json({ message: "Inscription confirmée" });
   } catch (error) {

--- a/types.d.ts
+++ b/types.d.ts
@@ -9,6 +9,8 @@ declare global {
         DATABASE_URL: string;
         NEXTAUTH_SECRET: string;
         NEXTAUTH_URL: string;
+        SENDINBLUE_API_KEY: string;
+        SENDINBLUE_LIST_ID: string;
       }
     }
   


### PR DESCRIPTION
## Summary
- connect newsletter API route to Sendinblue
- declare Sendinblue environment variables
- document newsletter configuration in the README

## Testing
- `npm install` *(fails: Error: Failed to fetch sha256 checksum at https://binaries.prisma.sh/... 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68414fc4412083238576344dba8824d9