### PR TITLE
Ajout des pages dashboard

### DIFF
--- a/app/dashboard/avis/page.tsx
+++ b/app/dashboard/avis/page.tsx
@@ -1,0 +1,44 @@
+export const dynamic = "force-dynamic";
+import { getServerSession } from "next-auth";
+import { getAuthOptions } from "@/lib/authOptions";
+import ListeAvis, { Avis } from "@/components/ListeAvis";
+import { motion } from "framer-motion";
+
+export default async function AvisDashboardPage() {
+  const session = await getServerSession(getAuthOptions());
+
+  let avis: Avis[] = [];
+
+  if (session?.user?.email) {
+    try {
+      const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/api/avis`, {
+        headers: {
+          Cookie: "", // nécessaire si tu fais une requête serveur vers toi-même
+        },
+        cache: "no-store",
+      });
+
+      if (res.ok) {
+        avis = await res.json();
+      } else {
+        console.error("Échec de la récupération des avis:", res.statusText);
+      }
+    } catch (error) {
+      console.error("Erreur de requête vers /api/avis:", error);
+    }
+  }
+
+  return (
+    <main className="p-6 space-y-6">
+      <motion.h1
+        initial={{ opacity: 0, y: -20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.5 }}
+        className="text-2xl font-bold"
+      >
+        Tous vos avis générés
+      </motion.h1>
+      <ListeAvis avis={avis} />
+    </main>
+  );
+}

--- a/app/dashboard/settings/page.tsx
+++ b/app/dashboard/settings/page.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import React, { useState } from "react";
+import { motion } from "framer-motion";
+
+export default function SettingsDashboardPage() {
+  const [notifications, setNotifications] = useState(true);
+  const [newsletter, setNewsletter] = useState(false);
+  const [publicProfile, setPublicProfile] = useState(true);
+
+  return (
+    <main className="p-6 space-y-6 max-w-xl">
+      <motion.h1
+        initial={{ opacity: 0, y: -20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.5 }}
+        className="text-2xl font-bold"
+      >
+        Paramètres
+      </motion.h1>
+      <form className="space-y-4">
+        <label className="flex items-center gap-3">
+          <input
+            type="checkbox"
+            checked={notifications}
+            onChange={(e) => setNotifications(e.target.checked)}
+            className="h-4 w-4"
+          />
+          <span>Recevoir les notifications</span>
+        </label>
+        <label className="flex items-center gap-3">
+          <input
+            type="checkbox"
+            checked={newsletter}
+            onChange={(e) => setNewsletter(e.target.checked)}
+            className="h-4 w-4"
+          />
+          <span>S'inscrire à la newsletter</span>
+        </label>
+        <label className="flex items-center gap-3">
+          <input
+            type="checkbox"
+            checked={publicProfile}
+            onChange={(e) => setPublicProfile(e.target.checked)}
+            className="h-4 w-4"
+          />
+          <span>Profil public</span>
+        </label>
+        <button
+          type="submit"
+          className="bg-pink-600 hover:bg-pink-700 text-white font-semibold px-4 py-2 rounded"
+        >
+          Enregistrer
+        </button>
+      </form>
+    </main>
+  );
+}

--- a/app/dashboard/stats/page.tsx
+++ b/app/dashboard/stats/page.tsx
@@ -1,0 +1,20 @@
+import { motion } from "framer-motion";
+import StatsChart from "@/components/StatsChart";
+import StatsSummary from "@/components/StatsSummary";
+
+export default function StatsDashboardPage() {
+  return (
+    <main className="p-6 space-y-6">
+      <motion.h1
+        initial={{ opacity: 0, y: -20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.5 }}
+        className="text-2xl font-bold"
+      >
+        Statistiques
+      </motion.h1>
+      <StatsSummary />
+      <StatsChart />
+    </main>
+  );
+}


### PR DESCRIPTION
## Notes
- Installation et build échouent dans l'environnement du bot.

## Summary
- created new directories for dashboard sub-pages
- added `/dashboard/avis` showing all reviews with `ListeAvis`
- added `/dashboard/stats` displaying `StatsSummary` and `StatsChart`
- added `/dashboard/settings` with a basic options form


------
https://chatgpt.com/codex/tasks/task_e_68414fc179dc832397328a0f72bedbf1