### PR TITLE
Simplify auth pages

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -4,8 +4,16 @@
 import React from "react";
 import { motion } from "framer-motion";
 import Link from "next/link";
+import { signIn } from "next-auth/react";
+import { useSearchParams } from "next/navigation";
 
 export default function LoginPage() {
+  const searchParams = useSearchParams();
+  const error = searchParams.get("error");
+
+  const errorMessage =
+    error ? "Échec de la connexion. Veuillez réessayer." : null;
+
   return (
     <main className="min-h-screen flex items-center justify-center bg-white dark:bg-black px-4">
       <motion.div
@@ -16,42 +24,14 @@ export default function LoginPage() {
       >
         <h2 className="text-2xl font-bold text-center text-pink-600">Connexion</h2>
 
-        <form className="space-y-4">
-          <div>
-            <label htmlFor="email" className="block text-sm font-medium mb-1">
-              Adresse email
-            </label>
-            <input
-              type="email"
-              id="email"
-              placeholder="you@example.com"
-              className="w-full px-4 py-2 rounded-lg bg-white dark:bg-zinc-800 text-black dark:text-white border border-zinc-300 dark:border-zinc-700 focus:outline-none focus:ring-2 focus:ring-pink-500"
-            />
-          </div>
+        {errorMessage && (
+          <p className="text-center text-sm text-red-500">{errorMessage}</p>
+        )}
 
-          <div>
-            <label htmlFor="password" className="block text-sm font-medium mb-1">
-              Mot de passe
-            </label>
-            <input
-              type="password"
-              id="password"
-              placeholder="••••••••"
-              className="w-full px-4 py-2 rounded-lg bg-white dark:bg-zinc-800 text-black dark:text-white border border-zinc-300 dark:border-zinc-700 focus:outline-none focus:ring-2 focus:ring-pink-500"
-            />
-          </div>
-
-          <button
-            type="submit"
-            className="w-full bg-pink-500 hover:bg-pink-600 text-white font-medium py-2 rounded-lg transition"
-          >
-            Se connecter
-          </button>
-        </form>
-
-        <div className="text-center text-sm text-zinc-500 dark:text-zinc-400">ou</div>
-
-        <button className="w-full flex items-center justify-center gap-2 bg-white dark:bg-zinc-800 border border-zinc-300 dark:border-zinc-600 py-2 rounded-lg hover:shadow-md transition">
+        <button
+          onClick={() => signIn("google")}
+          className="w-full flex items-center justify-center gap-2 bg-white dark:bg-zinc-800 border border-zinc-300 dark:border-zinc-600 py-2 rounded-lg hover:shadow-md transition"
+        >
           <img src="/google.svg" alt="Google" className="w-5 h-5" />
           <span className="text-sm font-medium">Connexion avec Google</span>
         </button>

--- a/app/register/page.tsx
+++ b/app/register/page.tsx
@@ -3,9 +3,16 @@
 import React from "react";
 import Link from "next/link";
 import { motion } from "framer-motion";
-import { Mail, Lock, User, LogIn } from "lucide-react";
+import { LogIn } from "lucide-react";
+import { signIn } from "next-auth/react";
+import { useSearchParams } from "next/navigation";
 
 export default function RegisterPage() {
+  const searchParams = useSearchParams();
+  const error = searchParams.get("error");
+  const errorMessage =
+    error ? "Échec de l'inscription. Veuillez réessayer." : null;
+
   return (
     <main className="min-h-screen flex items-center justify-center bg-white dark:bg-black text-black dark:text-white px-4">
       <motion.div
@@ -14,51 +21,16 @@ export default function RegisterPage() {
         transition={{ duration: 0.6 }}
         className="w-full max-w-md space-y-6 rounded-2xl p-8 bg-zinc-100 dark:bg-zinc-900 shadow-xl"
       >
-        <h1 className="text-3xl font-bold text-center text-pink-600">
-          Créer un compte
-        </h1>
+        <h1 className="text-3xl font-bold text-center text-pink-600">Créer un compte</h1>
 
-        <form className="space-y-5">
-          <div className="relative">
-            <User className="absolute left-3 top-3 text-pink-500" size={20} />
-            <input
-              type="text"
-              placeholder="Nom complet"
-              className="pl-10 w-full py-3 rounded-lg bg-white dark:bg-zinc-800 text-black dark:text-white border border-zinc-300 dark:border-zinc-700 focus:outline-none focus:ring-2 focus:ring-pink-500"
-            />
-          </div>
+        {errorMessage && (
+          <p className="text-center text-sm text-red-500">{errorMessage}</p>
+        )}
 
-          <div className="relative">
-            <Mail className="absolute left-3 top-3 text-pink-500" size={20} />
-            <input
-              type="email"
-              placeholder="Adresse email"
-              className="pl-10 w-full py-3 rounded-lg bg-white dark:bg-zinc-800 text-black dark:text-white border border-zinc-300 dark:border-zinc-700 focus:outline-none focus:ring-2 focus:ring-pink-500"
-            />
-          </div>
-
-          <div className="relative">
-            <Lock className="absolute left-3 top-3 text-pink-500" size={20} />
-            <input
-              type="password"
-              placeholder="Mot de passe"
-              className="pl-10 w-full py-3 rounded-lg bg-white dark:bg-zinc-800 text-black dark:text-white border border-zinc-300 dark:border-zinc-700 focus:outline-none focus:ring-2 focus:ring-pink-500"
-            />
-          </div>
-
-          <button
-            type="submit"
-            className="w-full bg-pink-600 hover:bg-pink-700 text-white font-semibold py-3 rounded-lg transition"
-          >
-            S’inscrire
-          </button>
-        </form>
-
-        <div className="text-center text-sm text-zinc-500 dark:text-zinc-400">
-          ou
-        </div>
-
-        <button className="w-full flex items-center justify-center gap-3 bg-white dark:bg-zinc-800 border border-zinc-300 dark:border-zinc-600 py-3 rounded-lg hover:shadow-md transition">
+        <button
+          onClick={() => signIn("google")}
+          className="w-full flex items-center justify-center gap-3 bg-white dark:bg-zinc-800 border border-zinc-300 dark:border-zinc-600 py-3 rounded-lg hover:shadow-md transition"
+        >
           <img src="/google.svg" alt="Google" className="w-5 h-5" />
           <span className="text-sm font-medium">S’inscrire avec Google</span>
         </button>

--- a/lib/authOptions.ts
+++ b/lib/authOptions.ts
@@ -26,5 +26,19 @@ export const getAuthOptions = (): NextAuthOptions => ({
       return token;
     },
   },
+  events: {
+    async error(message) {
+      console.error("NextAuth error:", message);
+      try {
+        await fetch(`${process.env.NEXTAUTH_URL}/api/log-error`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ error: String(message) }),
+        });
+      } catch (loggingError) {
+        console.error("Échec d'envoi du log NextAuth:", loggingError);
+      }
+    },
+  },
   debug: process.env.NODE_ENV === "development",
 });


### PR DESCRIPTION
## Summary
- replace the fake login and register forms with a Google sign-in button
- surface OAuth errors on the auth pages
- log NextAuth errors with a new `events.error` callback

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68414fc367f0832399e47034fca799a1