### PR TITLE
Remove duplicate SpeedInsights usage

### DIFF
--- a/components/Providers.tsx
+++ b/components/Providers.tsx
@@ -4,7 +4,6 @@ import React, { ReactNode } from "react";
 import { SessionProvider } from "next-auth/react";
 import { LazyMotion, domAnimation } from "framer-motion";
 import { ThemeProvider } from "next-themes";
-import { SpeedInsights } from "@vercel/speed-insights/next";
 import ErrorBoundary from "./ErrorBoundary";
 
 interface ProvidersProps {
@@ -21,10 +20,7 @@ export default function Providers({ children }: ProvidersProps) {
           enableSystem
           enableColorScheme
         >
-          <ErrorBoundary>
-            {children}
-            <SpeedInsights />
-          </ErrorBoundary>
+          <ErrorBoundary>{children}</ErrorBoundary>
         </ThemeProvider>
       </LazyMotion>
     </SessionProvider>


### PR DESCRIPTION
## Summary
- keep `SpeedInsights` rendering in `app/layout.tsx`
- remove duplicate rendering from `Providers`

## Testing
- `npm install` *(fails: Error: Failed to fetch sha256 checksum...)*

------
https://chatgpt.com/codex/tasks/task_e_68415049dc2c83238b49fb5e210a5a6c