### PR TITLE
Modernize metadata and 404 page

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -2,6 +2,12 @@
 
 import React from "react";
 import { motion } from "framer-motion";
+import { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "À propos | AvisAI",
+  description: "Apprenez-en plus sur la mission et la vision de l'équipe AvisAI.",
+};
 
 export default function PageAbout() {
   return (

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -2,8 +2,14 @@
 
 import React, { useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
-import Head from "next/head";
+import { Metadata } from "next";
 import { CheckCircle } from "lucide-react";
+
+export const metadata: Metadata = {
+  title: "Contact | AvisAI",
+  description:
+    "Contactez l'équipe d'AvisAI pour vos demandes de partenariat, démos ou support.",
+};
 
 export default function PageContact() {
   const [status, setStatus] = useState<"idle" | "sending" | "sent">("idle");
@@ -15,16 +21,7 @@ export default function PageContact() {
   };
 
   return (
-    <>
-      <Head>
-        <title>Contact | AvisAI</title>
-        <meta
-          name="description"
-          content="Contactez l'équipe d'AvisAI pour vos demandes de partenariat, démos ou support."
-        />
-      </Head>
-
-      <main className="min-h-screen bg-white dark:bg-zinc-950 px-6 py-24 text-black dark:text-white">
+    <main className="min-h-screen bg-white dark:bg-zinc-950 px-6 py-24 text-black dark:text-white">
         <div className="max-w-3xl mx-auto">
           <motion.h1
             className="text-4xl md:text-5xl font-bold mb-6 text-center"
@@ -112,6 +109,5 @@ export default function PageContact() {
           </AnimatePresence>
         </div>
       </main>
-    </>
   );
 }

--- a/app/features/page.tsx
+++ b/app/features/page.tsx
@@ -3,6 +3,13 @@
 import React, { useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { Rocket, Eye, Sparkles } from "lucide-react";
+import { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Fonctionnalités | AvisAI",
+  description:
+    "Découvrez comment AvisAI simplifie la génération et l'analyse de témoignages clients.",
+};
 import ButtonDuo from "@/components/ui/ButtonDuo";
 
 const allFeatures = [

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,18 @@
+import Link from "next/link";
+
+export default function NotFound() {
+  return (
+    <main className="min-h-screen flex flex-col items-center justify-center bg-white dark:bg-zinc-950 text-black dark:text-white px-6">
+      <h1 className="text-5xl font-extrabold mb-4">Page introuvable</h1>
+      <p className="text-gray-600 dark:text-gray-400 mb-8 text-center">
+        Oups ! La page que vous recherchez n'existe pas.
+      </p>
+      <Link
+        href="/"
+        className="px-6 py-3 rounded-lg bg-marque text-white hover:bg-red-600 transition"
+      >
+        Retour à l'accueil
+      </Link>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add static metadata to About, Contact and Features pages
- implement a custom not-found page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684152dae0e08323b4f7b8f41d9e79a8