### PR TITLE
Fix authOptions TypeScript typing

### DIFF
--- a/lib/authOptions.ts
+++ b/lib/authOptions.ts
@@ -27,7 +27,7 @@ export const getAuthOptions = (): NextAuthOptions => ({
     },
   },
   events: {
-    async error(message) {
+    async error(message: unknown) {
       console.error("NextAuth error:", message);
       try {
         await fetch(`${process.env.NEXTAUTH_URL}/api/log-error`, {
@@ -39,6 +39,8 @@ export const getAuthOptions = (): NextAuthOptions => ({
         console.error("Échec d'envoi du log NextAuth:", loggingError);
       }
     },
+  } as NextAuthOptions["events"] & {
+    error: (message: unknown) => Promise<void>;
   },
   debug: process.env.NODE_ENV === "development",
 });


### PR DESCRIPTION
## Summary
- type the `error` callback in `authOptions`'s `events` section
- add explicit type annotation for the message parameter
- confirm build via `npx tsc --noEmit`

## Testing
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_684159cf945883239bb9c34fa4fd50fd